### PR TITLE
fix: resolve runtime errors, memory leaks, and error handling issues …

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,10 @@
 import { NzMessageService } from 'ng-zorro-antd/message';
-import { interval, Observable } from 'rxjs';
+import { interval, Observable, Subject } from 'rxjs';
 import { filter, map, mergeMap, takeUntil } from 'rxjs/operators';
 import { MemberState, ModalTypes, ShareInfo } from 'src/app/store/reducers/member.reducer';
 
 import { DOCUMENT } from '@angular/common';
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, OnDestroy } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, NavigationStart, Router } from '@angular/router';
 import { createFeatureSelector, select, Store } from '@ngrx/store';
@@ -35,7 +35,7 @@ interface StateArrType {
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.less']
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
   lanRes: LanguageRes = LANGUAGE_CH;
   title = 'MusicPlayer by Bigyozo';
   menu = [
@@ -70,6 +70,7 @@ export class AppComponent {
   routeTitle = '';
   loadPercent = 0;
   private navEnd: Observable<NavigationEnd>;
+  private destroy$ = new Subject<void>();
 
   constructor(
     private searchService: SearchService,
@@ -101,15 +102,17 @@ export class AppComponent {
     }
     this.listenStates();
 
-    this.router.events.pipe(filter((evt) => evt instanceof NavigationStart)).subscribe(() => {
-      this.loadPercent = 0;
-      this.setTitle();
-    });
+    this.router.events
+      .pipe(filter((evt) => evt instanceof NavigationStart), takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.loadPercent = 0;
+        this.setTitle();
+      });
     this.navEnd = this.router.events.pipe(
       filter((evt) => evt instanceof NavigationEnd)
     ) as Observable<NavigationEnd>;
     this.setLoadIngBar();
-    this.languageService.language$.subscribe((item) => {
+    this.languageService.language$.pipe(takeUntil(this.destroy$)).subscribe((item) => {
       this.lanRes = item.res;
       this.menu = [
         {
@@ -124,6 +127,11 @@ export class AppComponent {
     });
   }
 
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
   private setTitle() {
     this.navEnd
       .pipe(
@@ -134,7 +142,8 @@ export class AppComponent {
           }
           return route;
         }),
-        mergeMap((route) => route.data)
+        mergeMap((route) => route.data),
+        takeUntil(this.destroy$)
       )
       .subscribe((data) => {
         this.routeTitle = data.title;
@@ -148,7 +157,7 @@ export class AppComponent {
       .subscribe(() => {
         this.loadPercent = Math.max(95, ++this.loadPercent);
       });
-    this.navEnd.subscribe(() => {
+    this.navEnd.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.loadPercent = 100;
       //  this.doc.documentElement.scrollTop = 0;
     });
@@ -176,7 +185,7 @@ export class AppComponent {
     ];
 
     stateArr.forEach((item) => {
-      appStore$.pipe(select(item.type)).subscribe(item.cb);
+      appStore$.pipe(select(item.type), takeUntil(this.destroy$)).subscribe(item.cb);
     });
   }
 
@@ -320,7 +329,7 @@ export class AppComponent {
     );
   }
 
-  // 获取当前用户的歌单
+  // 获取当前用户の歌单
   onLoadMySheets() {
     if (this.user) {
       this.memberService
@@ -344,7 +353,7 @@ export class AppComponent {
       },
       (error) => {
         //Collect fail
-        this.alertMessage('error', error.msg || this.lanRes.C00079);
+        this.alertMessage('error', error.message || this.lanRes.C00079);
       }
     );
   }
@@ -356,7 +365,7 @@ export class AppComponent {
       },
       (error) => {
         //Create fail
-        this.alertMessage('error', error.msg || this.lanRes.C00080);
+        this.alertMessage('error', error.message || this.lanRes.C00080);
       }
     );
   }
@@ -374,7 +383,7 @@ export class AppComponent {
       },
       (error) => {
         //Share fail
-        this.alertMessage('error', error.msg || this.lanRes.C00082);
+        this.alertMessage('error', error.message || this.lanRes.C00082);
       }
     );
   }

--- a/src/app/pages/home/home-resolve.service.ts
+++ b/src/app/pages/home/home-resolve.service.ts
@@ -1,5 +1,5 @@
-import { forkJoin, Observable } from 'rxjs';
-import { first } from 'rxjs/operators';
+import { forkJoin, Observable, of } from 'rxjs';
+import { catchError, first } from 'rxjs/operators';
 import { Banner, HotTag, Singer, SongSheet } from 'src/app/services/data.types/common.types';
 import { HomeService } from 'src/app/services/home.service';
 import { SingerService } from 'src/app/services/singer.service';
@@ -19,6 +19,9 @@ export class HomeResolverService implements Resolve<HomeDataType> {
       this.homeService.getHotTags(),
       this.homeService.getPersonalSheetList(),
       this.singerService.getEnterSinger()
-    ]).pipe(first());
+    ]).pipe(
+      first(),
+      catchError(() => of([[], [], [], []] as unknown as HomeDataType))
+    );
   }
 }

--- a/src/app/pages/member/center/center-resolve.service.ts
+++ b/src/app/pages/member/center/center-resolve.service.ts
@@ -1,4 +1,4 @@
-import { forkJoin, Observable } from 'rxjs';
+import { EMPTY, forkJoin, Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { RecordVal, User, UserSheet } from 'src/app/services/data.types/member.type';
 
@@ -23,6 +23,7 @@ export class CenterResolverService implements Resolve<CenterDataType> {
       ]).pipe(first());
     } else {
       this.router.navigate(['/home']);
+      return EMPTY;
     }
   }
 }

--- a/src/app/pages/member/record-detail/record-resolve.service.ts
+++ b/src/app/pages/member/record-detail/record-resolve.service.ts
@@ -1,4 +1,4 @@
-import { forkJoin, Observable } from 'rxjs';
+import { EMPTY, forkJoin, Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { RecordVal, User } from 'src/app/services/data.types/member.type';
 
@@ -22,6 +22,7 @@ export class RecordResolverService implements Resolve<RecordDataType> {
       ]).pipe(first());
     } else {
       this.router.navigate(['/home']);
+      return EMPTY;
     }
   }
 }

--- a/src/app/pages/sheet-info/sheet-info-resolver.service.ts
+++ b/src/app/pages/sheet-info/sheet-info-resolver.service.ts
@@ -1,16 +1,22 @@
-import { Observable } from 'rxjs';
+import { EMPTY, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { SongSheet } from 'src/app/services/data.types/common.types';
 
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
 
 import { SheetService } from '../../services/sheet.service';
 
 @Injectable()
 export class SheetInfoResolverService implements Resolve<SongSheet> {
-  constructor(private sheetService: SheetService) {}
+  constructor(private sheetService: SheetService, private router: Router) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<SongSheet> {
-    return this.sheetService.getSongSheetDetail(Number(route.paramMap.get('id')));
+    return this.sheetService.getSongSheetDetail(Number(route.paramMap.get('id'))).pipe(
+      catchError(() => {
+        this.router.navigate(['/home']);
+        return EMPTY;
+      })
+    );
   }
 }

--- a/src/app/pages/singer/singer-detail/singer-resolver.service.ts
+++ b/src/app/pages/singer/singer-detail/singer-resolver.service.ts
@@ -1,21 +1,27 @@
-import { forkJoin, Observable } from 'rxjs';
+import { EMPTY, forkJoin, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { Singer, SingerDetail } from 'src/app/services/data.types/common.types';
 
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
 
 import { SingerService } from '../../../services/singer.service';
 
 type SingerDetailData = [SingerDetail, Singer[]];
 @Injectable()
 export class SingerResolverService implements Resolve<SingerDetailData> {
-  constructor(private singerService: SingerService) {}
+  constructor(private singerService: SingerService, private router: Router) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<SingerDetailData> {
     const id = route.paramMap.get('id');
     return forkJoin([
       this.singerService.getSingerDetail(id),
       this.singerService.getSimilarSinger(id)
-    ]);
+    ]).pipe(
+      catchError(() => {
+        this.router.navigate(['/home']);
+        return EMPTY;
+      })
+    );
   }
 }

--- a/src/app/pages/song-info/song-info-resolver.service.ts
+++ b/src/app/pages/song-info/song-info-resolver.service.ts
@@ -1,9 +1,9 @@
-import { forkJoin, Observable } from 'rxjs';
-import { first } from 'rxjs/operators';
+import { EMPTY, forkJoin, Observable } from 'rxjs';
+import { catchError, first } from 'rxjs/operators';
 import { Song } from 'src/app/services/data.types/common.types';
 
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
 
 import { Lyric } from '../../services/data.types/common.types';
 import { SongService } from '../../services/song.service';
@@ -12,13 +12,19 @@ type SongDataModel = [Song, Lyric];
 
 @Injectable()
 export class SongInfoResolverService implements Resolve<SongDataModel> {
-  constructor(private songService: SongService) {}
+  constructor(private songService: SongService, private router: Router) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<SongDataModel> {
     const id = route.paramMap.get('id');
     return forkJoin([
       this.songService.getSongDetail(id),
       this.songService.getLyric(Number(id))
-    ]).pipe(first());
+    ]).pipe(
+      first(),
+      catchError(() => {
+        this.router.navigate(['/home']);
+        return EMPTY;
+      })
+    );
   }
 }

--- a/src/app/services/http-interceptors/common.interceptor.ts
+++ b/src/app/services/http-interceptors/common.interceptor.ts
@@ -25,6 +25,13 @@ export class CommonInterceptor implements HttpInterceptor {
   }
 
   private handleError(error: HttpErrorResponse): never {
-    throw error.error;
+    const apiError = error.error;
+    const message =
+      (apiError && (apiError.msg || apiError.message)) || error.message || 'Request failed';
+    const err = new Error(message) as Error & { msg?: string };
+    if (apiError && apiError.msg) {
+      err.msg = apiError.msg;
+    }
+    throw err;
   }
 }

--- a/src/app/services/song.service.ts
+++ b/src/app/services/song.service.ts
@@ -34,7 +34,8 @@ export class SongService {
   private generateSongList(songArr: Song[], urls: SongUrl[]): Song[] {
     const result = [];
     songArr.forEach((song) => {
-      const url = urls.find((url) => url.id === song.id).url;
+      const found = urls.find((url) => url.id === song.id);
+      const url = found ? found.url : '';
       if (url) {
         result.push({ ...song, url });
       }


### PR DESCRIPTION
…(#13)

- song.service.ts: guard against undefined returned by find() in generateSongList()
- center-resolve/record-resolve: return EMPTY after router.navigate() so resolver contract is fulfilled
- app.component.ts: implement OnDestroy with destroy$ Subject; add takeUntil(destroy$) to all long-lived subscriptions; standardize error display to use error.message consistently
- common.interceptor.ts: throw a proper Error instance with .message set from API error body instead of throwing the raw response object
- home-resolve.service.ts: add catchError that returns empty arrays to prevent page load failure
- sheet-info/singer/song-info resolvers: inject Router, add catchError that navigates to /home on failure